### PR TITLE
Switch to PointConnections class

### DIFF
--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -795,7 +795,7 @@ void GMLS::operator()(const GetAccurateTangentDirections&, const member_type& te
         }
         teamMember.team_barrier();
 
-        XYZ rel_coord = getRelativeCoord(target_index, i, _dimensions, &T);
+        XYZ rel_coord = _pc.getRelativeCoord(target_index, i, _dimensions, &T);
         double normal_coordinate = rel_coord[_dimensions-1];
 
         // apply coefficients to sample data
@@ -1007,7 +1007,7 @@ void GMLS::operator()(const ApplyCurvatureTargets&, const member_type& teamMembe
         }
         teamMember.team_barrier();
 
-        XYZ rel_coord = getRelativeCoord(target_index, i, _dimensions, &T);
+        XYZ rel_coord = _pc.getRelativeCoord(target_index, i, _dimensions, &T);
         double normal_coordinate = rel_coord[_dimensions-1];
 
         // apply coefficients to sample data
@@ -1282,8 +1282,8 @@ void GMLS::operator()(const ComputePrestencilWeights&, const member_type& teamMe
                 for (int quadrature = 0; quadrature<_qm.getNumberOfQuadraturePoints(); ++quadrature) {
                     XYZ tangent_quadrature_coord_2d;
                     for (int j=0; j<_dimensions-1; ++j) {
-                        tangent_quadrature_coord_2d[j] = getTargetCoordinate(target_index, j, &T);
-                        tangent_quadrature_coord_2d[j] -= getNeighborCoordinate(target_index, m, j, &T);
+                        tangent_quadrature_coord_2d[j]  = _pc.getTargetCoordinate(target_index, j, &T);
+                        tangent_quadrature_coord_2d[j] -= _pc.getNeighborCoordinate(target_index, m, j, &T);
                     }
                     double tangent_vector[3];
                     tangent_vector[0] = tangent_quadrature_coord_2d[0]*T(0,0) + tangent_quadrature_coord_2d[1]*T(1,0);
@@ -1314,7 +1314,7 @@ void GMLS::operator()(const ComputePrestencilWeights&, const member_type& teamMe
                 for (int l=0; l<manifold_NP; ++l) {
                     alpha_ij += delta(l)*Q(l,i);
                 }
-                XYZ rel_coord = getRelativeCoord(target_index, i, _dimensions, &T);
+                XYZ rel_coord = _pc.getRelativeCoord(target_index, i, _dimensions, &T);
                 double normal_coordinate = rel_coord[_dimensions-1];
 
                 // apply coefficients to sample data
@@ -1330,7 +1330,7 @@ void GMLS::operator()(const ComputePrestencilWeights&, const member_type& teamMe
                 for (int l=0; l<manifold_NP; ++l) {
                     alpha_ij += delta(l)*Q(l,i);
                 }
-                XYZ rel_coord = getRelativeCoord(target_index, i, _dimensions, &T);
+                XYZ rel_coord = _pc.getRelativeCoord(target_index, i, _dimensions, &T);
                 double normal_coordinate = rel_coord[_dimensions-1];
 
                 // apply coefficients to sample data

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -12,6 +12,7 @@
 #include "Compadre_ScalarTaylorPolynomial.hpp"
 #include "Compadre_DivergenceFreePolynomial.hpp"
 #include "Compadre_NeighborLists.hpp"
+#include "Compadre_PointConnections.hpp"
 
 namespace Compadre {
 
@@ -81,6 +82,9 @@ protected:
 
     //! coordinates for target sites for reconstruction (device)
     Kokkos::View<double**, layout_right> _target_coordinates; 
+
+    //! connections between points and neighbors
+    PointConnections<decltype(_target_coordinates), decltype(_source_coordinates), decltype(_neighbor_lists)> _pc;
 
     //! h supports determined through neighbor search (device)
     Kokkos::View<double*> _epsilons; 
@@ -1339,6 +1343,7 @@ public:
         this->setSourceSites<view_type_2>(source_coordinates);
         this->setTargetSites<view_type_3>(target_coordinates);
         this->setWindowSizes<view_type_4>(epsilons);
+        
     }
 
     //! Sets basic problem data (neighbor lists data, number of neighbors list, source coordinates, and target coordinates)

--- a/src/Compadre_GMLS_Basis.hpp
+++ b/src/Compadre_GMLS_Basis.hpp
@@ -40,7 +40,7 @@ void GMLS::calcPij(const member_type& teamMember, double* delta, double* thread_
         for (int i=0; i<dimension; ++i) {
             // evaluation_site_local_index is for evaluation site, which includes target site
             // the -1 converts to the local index for ADDITIONAL evaluation sites
-            relative_coord[i]  = getTargetAuxiliaryCoordinate(target_index, evaluation_site_local_index-1, i, V);
+            relative_coord[i]  = _additional_pc.getNeighborCoordinate(target_index, evaluation_site_local_index-1, i, V);
             relative_coord[i] -= _pc.getTargetCoordinate(target_index, i, V);
         }
     } else {
@@ -413,7 +413,7 @@ void GMLS::calcPij(const member_type& teamMember, double* delta, double* thread_
                 if (_problem_type == ProblemType::MANIFOLD) {
                     XYZ qp = XYZ(transformed_qp[0], transformed_qp[1], transformed_qp[2]);
                     for (int j=0; j<2; ++j) {
-                        relative_coord[j] = convertGlobalToLocalCoordinate(qp,j,*V) - _pc.getTargetCoordinate(target_index,j,V); // shift quadrature point by target site
+                        relative_coord[j] = _pc.convertGlobalToLocalCoordinate(qp,j,*V) - _pc.getTargetCoordinate(target_index,j,V); // shift quadrature point by target site
                         relative_coord[2] = 0;
                     }
                 } else {
@@ -501,7 +501,7 @@ void GMLS::calcGradientPij(const member_type& teamMember, double* delta, double*
         for (int i=0; i<dimension; ++i) {
             // evaluation_site_local_index is for evaluation site, which includes target site
             // the -1 converts to the local index for ADDITIONAL evaluation sites
-            relative_coord[i]  = getTargetAuxiliaryCoordinate(target_index, evaluation_site_local_index-1, i, V);
+            relative_coord[i]  = _additional_pc.getNeighborCoordinate(target_index, evaluation_site_local_index-1, i, V);
             relative_coord[i] -= _pc.getTargetCoordinate(target_index, i, V);
         }
     } else {
@@ -566,7 +566,7 @@ void GMLS::calcHessianPij(const member_type& teamMember, double* delta, double* 
         for (int i=0; i<dimension; ++i) {
             // evaluation_site_local_index is for evaluation site, which includes target site
             // the -1 converts to the local index for ADDITIONAL evaluation sites
-            relative_coord[i]  = getTargetAuxiliaryCoordinate(target_index, evaluation_site_local_index-1, i, V);
+            relative_coord[i]  = _additional_pc.getNeighborCoordinate(target_index, evaluation_site_local_index-1, i, V);
             relative_coord[i] -= _pc.getTargetCoordinate(target_index, i, V);
         }
     } else {

--- a/src/Compadre_GMLS_Targets.hpp
+++ b/src/Compadre_GMLS_Targets.hpp
@@ -186,7 +186,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                                 Kokkos::subview(T, Kokkos::ALL(), 1), Kokkos::subview(T, Kokkos::ALL(), 2));
 
                         for (int j=0; j<3; ++j) {
-                            relative_coord[j] = transformed_qp[j] - getTargetCoordinate(target_index, j); // shift quadrature point by target site
+                            relative_coord[j] = transformed_qp[j] - _pc.getTargetCoordinate(target_index, j); // shift quadrature point by target site
                         }
 
                         int k = 0;
@@ -1529,8 +1529,8 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                         for (int d=0; d<_dimensions-1; ++d) {
                             // k indexing is for evaluation site, which includes target site
                             // the k-1 converts to the local index for ADDITIONAL evaluation sites
-                            relative_coord[d] = getTargetAuxiliaryCoordinate(target_index, k-1, d, &V);
-                            relative_coord[d] -= getTargetCoordinate(target_index, d, &V);
+                            relative_coord[d]  = getTargetAuxiliaryCoordinate(target_index, k-1, d, &V);
+                            relative_coord[d] -= _pc.getTargetCoordinate(target_index, d, &V);
                         }
                     } else {
                         for (int i=0; i<3; ++i) relative_coord[i] = 0;
@@ -1550,8 +1550,8 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                         for (int d=0; d<_dimensions-1; ++d) {
                             // k indexing is for evaluation site, which includes target site
                             // the k-1 converts to the local index for ADDITIONAL evaluation sites
-                            relative_coord[d] = getTargetAuxiliaryCoordinate(target_index, k-1, d, &V);
-                            relative_coord[d] -= getTargetCoordinate(target_index, d, &V);
+                            relative_coord[d]  = getTargetAuxiliaryCoordinate(target_index, k-1, d, &V);
+                            relative_coord[d] -= _pc.getTargetCoordinate(target_index, d, &V);
                         }
                     } else {
                         for (int i=0; i<3; ++i) relative_coord[i] = 0;
@@ -1648,7 +1648,7 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
 
                         XYZ qp = XYZ(transformed_qp[0], transformed_qp[1], transformed_qp[2]);
                         for (int j=0; j<2; ++j) {
-                            relative_coord[j] = convertGlobalToLocalCoordinate(qp,j,&V) - getTargetCoordinate(target_index,j,&V); // shift quadrature point by target site
+                            relative_coord[j] = convertGlobalToLocalCoordinate(qp,j,V) - _pc.getTargetCoordinate(target_index,j,&V); // shift quadrature point by target site
                             relative_coord[2] = 0;
                         }
 

--- a/src/Compadre_GMLS_Targets.hpp
+++ b/src/Compadre_GMLS_Targets.hpp
@@ -1529,7 +1529,7 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                         for (int d=0; d<_dimensions-1; ++d) {
                             // k indexing is for evaluation site, which includes target site
                             // the k-1 converts to the local index for ADDITIONAL evaluation sites
-                            relative_coord[d]  = getTargetAuxiliaryCoordinate(target_index, k-1, d, &V);
+                            relative_coord[d]  = _additional_pc.getNeighborCoordinate(target_index, k-1, d, &V);
                             relative_coord[d] -= _pc.getTargetCoordinate(target_index, d, &V);
                         }
                     } else {
@@ -1550,7 +1550,7 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                         for (int d=0; d<_dimensions-1; ++d) {
                             // k indexing is for evaluation site, which includes target site
                             // the k-1 converts to the local index for ADDITIONAL evaluation sites
-                            relative_coord[d]  = getTargetAuxiliaryCoordinate(target_index, k-1, d, &V);
+                            relative_coord[d]  = _additional_pc.getNeighborCoordinate(target_index, k-1, d, &V);
                             relative_coord[d] -= _pc.getTargetCoordinate(target_index, d, &V);
                         }
                     } else {
@@ -1648,7 +1648,7 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
 
                         XYZ qp = XYZ(transformed_qp[0], transformed_qp[1], transformed_qp[2]);
                         for (int j=0; j<2; ++j) {
-                            relative_coord[j] = convertGlobalToLocalCoordinate(qp,j,V) - _pc.getTargetCoordinate(target_index,j,&V); // shift quadrature point by target site
+                            relative_coord[j] = _pc.convertGlobalToLocalCoordinate(qp,j,V) - _pc.getTargetCoordinate(target_index,j,&V); // shift quadrature point by target site
                             relative_coord[2] = 0;
                         }
 

--- a/src/Compadre_PointConnections.hpp
+++ b/src/Compadre_PointConnections.hpp
@@ -1,0 +1,53 @@
+#ifndef _COMPADRE_POINTCONNECTIONS_HPP_
+#define _COMPADRE_POINTCONNECTIONS_HPP_
+
+#include "Compadre_Typedefs.hpp"
+#include <Kokkos_Core.hpp>
+
+namespace Compadre {
+
+//!  Combines NeighborLists with the PointClouds from which it was derived
+template <typename view_type_1, typename view_type_2, typename view_type_3>
+class PointConnections {
+public:
+
+    //! source site coordinates on device
+    typedef decltype(Kokkos::create_mirror_view<device_memory_space>(
+                device_memory_space(), view_type_1()))
+                        device_mirror_target_view_type;
+
+    //! target site coordinates on device
+    typedef decltype(Kokkos::create_mirror_view<device_memory_space>(
+                device_memory_space(), view_type_2()))
+                        device_mirror_source_view_type;
+
+    device_mirror_target_view_type _target_coordinates;
+    device_mirror_source_view_type _source_coordinates;
+    NeighborLists<view_type_3> _nla;
+
+/** @name Constructors
+ */
+///@{
+
+    //! \brief Constructor for PointConnections
+    PointConnections(Kokkos::View<view_type_1> target_coordinates, 
+                     Kokkos::View<view_type_2> source_coordinates,
+                     NeighborLists<view_type_3> nla) : {
+
+        _target_coordinates = Kokkos::create_mirror_view<device_memory_space>(
+                device_memory_space(), view_type_1())
+        _source_coordinates = Kokkos::create_mirror_view<device_memory_space>(
+                device_memory_space(), view_type_2())
+        Kokkos::deep_copy(_target_coordinates, target_coordinates);
+        Kokkos::deep_copy(_source_coordinates, source_coordinates);
+
+    }
+
+///@}
+
+}; // PointConnections
+
+} // Compadre namespace
+
+#endif
+

--- a/src/Compadre_PointConnections.hpp
+++ b/src/Compadre_PointConnections.hpp
@@ -7,40 +7,159 @@
 namespace Compadre {
 
 //!  Combines NeighborLists with the PointClouds from which it was derived
-template <typename view_type_1, typename view_type_2, typename view_type_3>
+//!  Assumed that memory_space is the same as device, but it can be set to
+//!  host, if desired.
+template <typename view_type_1, typename view_type_2, typename nla_type, typename memory_space = device_memory_space>
 class PointConnections {
 public:
 
     //! source site coordinates on device
-    typedef decltype(Kokkos::create_mirror_view<device_memory_space>(
-                device_memory_space(), view_type_1()))
+    typedef decltype(Kokkos::create_mirror_view<memory_space>(
+                memory_space(), view_type_1()))
                         device_mirror_target_view_type;
 
     //! target site coordinates on device
-    typedef decltype(Kokkos::create_mirror_view<device_memory_space>(
-                device_memory_space(), view_type_2()))
+    typedef decltype(Kokkos::create_mirror_view<memory_space>(
+                memory_space(), view_type_2()))
                         device_mirror_source_view_type;
 
     device_mirror_target_view_type _target_coordinates;
     device_mirror_source_view_type _source_coordinates;
-    NeighborLists<view_type_3> _nla;
+    nla_type _nla;
 
 /** @name Constructors
  */
 ///@{
 
     //! \brief Constructor for PointConnections
-    PointConnections(Kokkos::View<view_type_1> target_coordinates, 
-                     Kokkos::View<view_type_2> source_coordinates,
-                     NeighborLists<view_type_3> nla) : {
+    PointConnections(view_type_1 target_coordinates, 
+                     view_type_2 source_coordinates,
+                     nla_type nla) : _nla(nla) {
 
-        _target_coordinates = Kokkos::create_mirror_view<device_memory_space>(
-                device_memory_space(), view_type_1())
-        _source_coordinates = Kokkos::create_mirror_view<device_memory_space>(
-                device_memory_space(), view_type_2())
+        _target_coordinates = Kokkos::create_mirror_view<memory_space>(
+                memory_space(), target_coordinates);
+        _source_coordinates = Kokkos::create_mirror_view<memory_space>(
+                memory_space(), source_coordinates);
         Kokkos::deep_copy(_target_coordinates, target_coordinates);
         Kokkos::deep_copy(_source_coordinates, source_coordinates);
+        printf("point connections made with: %d targets, %d sources\n", _target_coordinates.extent(0), _source_coordinates.extent(0));
 
+    }
+
+    PointConnections() {}
+
+    // copy constructor (can be used to move data from device to host or vice-versa)
+    template <typename other_type_1, typename other_type_2, typename other_type_3>
+    PointConnections(const PointConnections<other_type_1, other_type_2, other_type_3> &other) : 
+        PointConnections(other._target_coordinates, other._source_coordinates, other._nla) {}
+
+///@}
+
+/** @name Public Utility
+ *  
+ */
+///@{
+
+    //! Returns a component of the local coordinate after transformation from global to local under the orthonormal basis V.
+    KOKKOS_INLINE_FUNCTION
+    static double convertGlobalToLocalCoordinate(const XYZ global_coord, const int dim, const scratch_matrix_right_type& V) {
+        compadre_assert_release(dim<3);
+        // only written for 2d manifold in 3d space or 2D problem with 1D manifold
+        double val = 0;
+        val += global_coord.x * V(dim, 0);
+        if (V.extent_int(1)>1) val += global_coord.y * V(dim, 1); 
+        if (V.extent_int(1)>2) val += global_coord.z * V(dim, 2);
+        return val;
+    }
+
+    //! Returns a component of the global coordinate after transformation from local to global under the orthonormal basis V^T.
+    KOKKOS_INLINE_FUNCTION
+    static double convertLocalToGlobalCoordinate(const XYZ local_coord, const int dim, const scratch_matrix_right_type& V) {
+        double val = 0.0;
+        if (dim == 0 && V.extent_int(0)==1) { // 2D problem with 1D manifold
+            val = local_coord.x * V(0, dim);
+        } else if (dim == 0) { // 3D problem with 2D manifold
+            val = local_coord.x * (V(0, dim) + V(1, dim));
+        } else if (dim == 1) { // 3D problem with 2D manifold
+            val = local_coord.y * (V(0, dim) + V(1, dim));
+        }
+        return val;
+    }
+
+    //! Returns Euclidean norm of a vector
+    KOKKOS_INLINE_FUNCTION
+    static double EuclideanVectorLength(const XYZ& delta_vector, const int dimension) {
+        double inside_val = delta_vector.x*delta_vector.x;
+        switch (dimension) {
+        case 3:
+            inside_val += delta_vector.z*delta_vector.z;
+            // no break is intentional
+        case 2:
+            inside_val += delta_vector.y*delta_vector.y;
+            // no break is intentional
+        default:
+            break;
+        }
+        return std::sqrt(inside_val);
+    }
+
+
+///@}
+
+/** @name Public Accessors
+ */
+///@{
+
+    //! Returns one component of the target coordinate for a particular target. Whether global or local coordinates 
+    //! depends upon V being specified
+    KOKKOS_INLINE_FUNCTION
+    double getTargetCoordinate(const int target_index, const int dim, const scratch_matrix_right_type* V = NULL) const {
+        compadre_kernel_assert_debug((_target_coordinates.extent(0) >= (size_t)target_index) && "Target index is out of range for _target_coordinates.");
+        if (V==NULL) {
+            return _target_coordinates(target_index, dim);
+        } else {
+            XYZ target_coord = XYZ( _target_coordinates(target_index, 0), 
+                                    _target_coordinates(target_index, 1), 
+                                    _target_coordinates(target_index, 2));
+            return this->convertGlobalToLocalCoordinate(target_coord, dim, *V);
+        }
+    }
+
+    //! Returns one component of the neighbor coordinate for a particular target. Whether global or local coordinates 
+    //! depends upon V being specified
+    KOKKOS_INLINE_FUNCTION
+    double getNeighborCoordinate(const int target_index, const int neighbor_list_num, const int dim, const scratch_matrix_right_type* V = NULL) const {
+        compadre_kernel_assert_debug((_source_coordinates.extent(0) >= (size_t)(this->getNeighborIndex(target_index, neighbor_list_num))) && "Source index is out of range for _source_coordinates.");
+        if (V==NULL) {
+            return _source_coordinates(this->getNeighborIndex(target_index, neighbor_list_num), dim);
+        } else {
+            XYZ neighbor_coord = XYZ(_source_coordinates(this->getNeighborIndex(target_index, neighbor_list_num), 0), _source_coordinates(this->getNeighborIndex(target_index, neighbor_list_num), 1), _source_coordinates(this->getNeighborIndex(target_index, neighbor_list_num), 2));
+            return this->convertGlobalToLocalCoordinate(neighbor_coord, dim, *V);
+        }
+    }
+
+    //! Returns the relative coordinate as a vector between the target site and the neighbor site. 
+    //! Whether global or local coordinates depends upon V being specified
+    KOKKOS_INLINE_FUNCTION
+    XYZ getRelativeCoord(const int target_index, const int neighbor_list_num, const int dimension, const scratch_matrix_right_type* V = NULL) const {
+        XYZ coordinate_delta;
+
+        auto p1 = this->getNeighborCoordinate(target_index, neighbor_list_num, 0, V);
+        auto p2 = this->getTargetCoordinate(target_index, 0, V);
+
+        coordinate_delta.x = p1-p2;
+        //coordinate_delta.x = this->getNeighborCoordinate(target_index, neighbor_list_num, 0, V) - this->getTargetCoordinate(target_index, 0, V);
+        coordinate_delta.y = this->getNeighborCoordinate(target_index, neighbor_list_num, 1, V) - this->getTargetCoordinate(target_index, 1, V);
+        if (dimension>2) coordinate_delta.z = this->getNeighborCoordinate(target_index, neighbor_list_num, 2, V) - this->getTargetCoordinate(target_index, 2, V);
+
+        return coordinate_delta;
+    }
+
+    //! Mapping from [0,number of neighbors for a target] to the row that contains the source coordinates for
+    //! that neighbor
+    KOKKOS_INLINE_FUNCTION
+    int getNeighborIndex(const int target_index, const int neighbor_list_num) const {
+        return _nla.getNeighborDevice(target_index, neighbor_list_num);
     }
 
 ///@}


### PR DESCRIPTION
Replace use of `_source_coordinates`, `_target_coordinates`, and neighbor list accessors in GMLS methods by encapsulating these items in the PointConnections class. Also, moved all methods from the GMLS class that rely only on these entities now contained in a PointConnections class.

Part of addressing issue #253 