### PR TITLE
Add option 'implicit_RHS' to QR solver

### DIFF
--- a/src/Compadre_LinearAlgebra.cpp
+++ b/src/Compadre_LinearAlgebra.cpp
@@ -24,6 +24,7 @@ namespace GMLS_LinearAlgebra {
     int _pm_getTeamScratchLevel_0;
     int _pm_getTeamScratchLevel_1;
     int _M, _N, _NRHS;
+    bool _implicit_RHS;
 
     KOKKOS_INLINE_FUNCTION
     Functor_TestBatchedTeamVectorSolveUTV(
@@ -31,8 +32,10 @@ namespace GMLS_LinearAlgebra {
                       const int N,
                       const int NRHS,
                       const MatrixViewType_A &a,
-                      const MatrixViewType_B &b)
-      : _a(a), _b(b), _M(M), _N(N), _NRHS(NRHS) { _pm_getTeamScratchLevel_0 = 0; _pm_getTeamScratchLevel_1 = 0; }
+                      const MatrixViewType_B &b,
+                      const bool implicit_RHS)
+      : _a(a), _b(b), _M(M), _N(N), _NRHS(NRHS), _implicit_RHS(implicit_RHS) 
+        { _pm_getTeamScratchLevel_0 = 0; _pm_getTeamScratchLevel_1 = 0; }
 
     template<typename MemberType>
     KOKKOS_INLINE_FUNCTION
@@ -140,7 +143,7 @@ namespace GMLS_LinearAlgebra {
         });
       }
       TeamVectorSolveUTVCompadre<MemberType,AlgoTagType>
-        ::invoke(member, matrix_rank, _M, _N, _NRHS, uu, aa, vv, pp, bb, xx, ww_slow, ww_fast);
+        ::invoke(member, matrix_rank, _M, _N, _NRHS, uu, aa, vv, pp, bb, xx, ww_slow, ww_fast, _implicit_RHS);
       member.team_barrier();
 
     }
@@ -180,7 +183,7 @@ namespace GMLS_LinearAlgebra {
 
 
 template <typename A_layout, typename B_layout, typename X_layout>
-void batchQRPivotingSolve(ParallelManager pm, double *A, int lda, int nda, double *B, int ldb, int ndb, int M, int N, int NRHS, const int num_matrices) {
+void batchQRPivotingSolve(ParallelManager pm, double *A, int lda, int nda, double *B, int ldb, int ndb, int M, int N, int NRHS, const int num_matrices, const bool implicit_RHS) {
 
     typedef Algo::UTV::Unblocked algo_tag_type;
     typedef Kokkos::View<double***, A_layout, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
@@ -194,18 +197,18 @@ void batchQRPivotingSolve(ParallelManager pm, double *A, int lda, int nda, doubl
     MatrixViewType_B mat_B(B, num_matrices, ldb, ndb);
 
     Functor_TestBatchedTeamVectorSolveUTV
-      <device_execution_space, algo_tag_type, MatrixViewType_A, MatrixViewType_B, MatrixViewType_X>(M,N,NRHS,mat_A,mat_B).run(pm);
+      <device_execution_space, algo_tag_type, MatrixViewType_A, MatrixViewType_B, MatrixViewType_X>(M,N,NRHS,mat_A,mat_B,implicit_RHS).run(pm);
 
 }
 
-template void batchQRPivotingSolve<layout_right, layout_right, layout_right>(ParallelManager,double*,int,int,double*,int,int,int,int,int,const int);
-template void batchQRPivotingSolve<layout_right, layout_right, layout_left >(ParallelManager,double*,int,int,double*,int,int,int,int,int,const int);
-template void batchQRPivotingSolve<layout_right, layout_left , layout_right>(ParallelManager,double*,int,int,double*,int,int,int,int,int,const int);
-template void batchQRPivotingSolve<layout_right, layout_left , layout_left >(ParallelManager,double*,int,int,double*,int,int,int,int,int,const int);
-template void batchQRPivotingSolve<layout_left , layout_right, layout_right>(ParallelManager,double*,int,int,double*,int,int,int,int,int,const int);
-template void batchQRPivotingSolve<layout_left , layout_right, layout_left >(ParallelManager,double*,int,int,double*,int,int,int,int,int,const int);
-template void batchQRPivotingSolve<layout_left , layout_left , layout_right>(ParallelManager,double*,int,int,double*,int,int,int,int,int,const int);
-template void batchQRPivotingSolve<layout_left , layout_left , layout_left >(ParallelManager,double*,int,int,double*,int,int,int,int,int,const int);
+template void batchQRPivotingSolve<layout_right, layout_right, layout_right>(ParallelManager,double*,int,int,double*,int,int,int,int,int,const int,const bool);
+template void batchQRPivotingSolve<layout_right, layout_right, layout_left >(ParallelManager,double*,int,int,double*,int,int,int,int,int,const int,const bool);
+template void batchQRPivotingSolve<layout_right, layout_left , layout_right>(ParallelManager,double*,int,int,double*,int,int,int,int,int,const int,const bool);
+template void batchQRPivotingSolve<layout_right, layout_left , layout_left >(ParallelManager,double*,int,int,double*,int,int,int,int,int,const int,const bool);
+template void batchQRPivotingSolve<layout_left , layout_right, layout_right>(ParallelManager,double*,int,int,double*,int,int,int,int,int,const int,const bool);
+template void batchQRPivotingSolve<layout_left , layout_right, layout_left >(ParallelManager,double*,int,int,double*,int,int,int,int,int,const int,const bool);
+template void batchQRPivotingSolve<layout_left , layout_left , layout_right>(ParallelManager,double*,int,int,double*,int,int,int,int,int,const int,const bool);
+template void batchQRPivotingSolve<layout_left , layout_left , layout_left >(ParallelManager,double*,int,int,double*,int,int,int,int,int,const int,const bool);
 
 } // GMLS_LinearAlgebra
 } // Compadre

--- a/src/Compadre_LinearAlgebra_Declarations.hpp
+++ b/src/Compadre_LinearAlgebra_Declarations.hpp
@@ -42,9 +42,10 @@ namespace GMLS_LinearAlgebra {
         \param N                    [in] - number of columns containing data in each matrix in A
         \param NRHS                 [in] - number of columns containing data in each matrix in B
         \param num_matrices         [in] - number of problems
+        \param implicit_RHS         [in] - determines whether RHS will be stored implicitly. If true, instead of RHS storing the full sqrt(W) explicitly, only the diagonal entries of sqrt(W) will be stored as a 1D array beginning at entry with matrix coordinate (0,0).
     */
     template <typename A_layout=layout_right, typename B_layout=layout_right, typename X_layout=layout_right>
-    void batchQRPivotingSolve(ParallelManager pm, double *A, int lda, int nda, double *B, int ldb, int ndb, int M, int N, int NRHS, const int num_matrices);
+    void batchQRPivotingSolve(ParallelManager pm, double *A, int lda, int nda, double *B, int ldb, int ndb, int M, int N, int NRHS, const int num_matrices, const bool implicit_RHS = true);
 
 } // GMLS_LinearAlgebra
 } // Compadre

--- a/src/tpl/KokkosBatched_SolveUTV_Decl_Compadre.hpp
+++ b/src/tpl/KokkosBatched_SolveUTV_Decl_Compadre.hpp
@@ -48,7 +48,8 @@ namespace KokkosBatched {
        const BViewType &B,
        const XViewType &X,
        const wViewType &w_a,
-       const wViewType &w_b);
+       const wViewType &w_b,
+       const bool implicit_RHS);
   };
 
 }

--- a/src/tpl/KokkosBatched_SolveUTV_TeamVector_Impl_Compadre.hpp
+++ b/src/tpl/KokkosBatched_SolveUTV_TeamVector_Impl_Compadre.hpp
@@ -32,7 +32,8 @@ namespace KokkosBatched {
              const BViewType &B,
              const XViewType &X,
              const wViewType &w_a,
-             const wViewType &w_b) {
+             const wViewType &w_b,
+             const bool implicit_RHS) {
               TeamVectorSolveUTV_Internal_Compadre::
                 invoke(member,
                    matrix_rank, m, n, nrhs,
@@ -42,7 +43,8 @@ namespace KokkosBatched {
                    p.data(), p.stride(0),
                    B.data(), B.stride(0), B.stride(1),
                    X.data(), X.stride(0), X.stride(1),
-                   w_a.data(), w_b.data());
+                   w_a.data(), w_b.data(),
+                   implicit_RHS);
                 return 0;
         }
     };

--- a/src/tpl/KokkosBatched_SolveUTV_TeamVector_Internal_Compadre.hpp
+++ b/src/tpl/KokkosBatched_SolveUTV_TeamVector_Internal_Compadre.hpp
@@ -40,7 +40,8 @@ namespace KokkosBatched {
            const IntType   * p, const int ps0,
            /* */ ValueType * B, const int bs0, const int bs1,
            /* */ ValueType * X, const int xs0, const int xs1,
-           /* */ ValueType * w, ValueType * wq) {
+           /* */ ValueType * w, ValueType * wq, 
+           const bool implicit_RHS) {
     
         typedef ValueType value_type;
     
@@ -72,7 +73,7 @@ namespace KokkosBatched {
             // T is matrix_rank x matrix_rank
             // V is matrix_rank x n
             // W = U^T B
-            if (m==n) { // LU case
+            if (!implicit_RHS) { // LU case
                 TeamVectorGemmInternal<Algo::Gemm::Unblocked>
                   ::invoke(member,
                        matrix_rank, nrhs, m,
@@ -156,7 +157,7 @@ namespace KokkosBatched {
                 });
             }
         } else {
-            if (m==n) { // LU case
+            if (!implicit_RHS) { // LU case
                 /// W = U^T B
                 TeamVectorGemmInternal<Algo::Gemm::Unblocked>
                   ::invoke(member,


### PR DESCRIPTION
When solving a QR problem for GMLS, it is not always necessary to form the entire sqrt(W)*I matrix, as a 1D vector containing only the diagonal entries of the matrix can suffice.

Previously, this case was inferred when M!=N in the solver. However, if the number of neighbors found are exactly equal to the cardinality of the basis, then it was assumed that a non-implicit storage was
used for the RHS (bug).

This commit introduces `implicit_RHS`, determined by whether the LU solver is requested or not, and passes this into the QR solver. These changes will make the storage format more obvious to developers, fix a bug, and remove reliance on sizing arguments to determine intention.