### PR TITLE
Clean up redundant variables in pycompadre

### DIFF
--- a/examples/GMLS_Manifold_Multiple_Evaluation_Sites.cpp
+++ b/examples/GMLS_Manifold_Multiple_Evaluation_Sites.cpp
@@ -518,7 +518,7 @@ Kokkos::initialize(argc, args);
     Kokkos::deep_copy(prestencil_weights, d_prestencil_weights);
 
     // tangent vector at target sites are stored here
-    auto d_tangent_directions = my_GMLS_vector_of_scalar_clones.getTangentDirections();
+    auto d_tangent_directions = *(my_GMLS_vector_of_scalar_clones.getTangentDirections());
     auto tangent_directions = Kokkos::create_mirror_view(d_tangent_directions);
     Kokkos::deep_copy(tangent_directions, d_tangent_directions);
 

--- a/examples/Python_3D_Convergence.py.in
+++ b/examples/Python_3D_Convergence.py.in
@@ -80,9 +80,6 @@ def test1(ND):
     gmls_helper.generateKDTree(source_sites)
     gmls_helper.generateNeighborListsFromKNNSearchAndSet(target_sites, polyOrder, dimensions, epsilon_multiplier)
 
-    # set data in gmls object
-    gmls_helper.setSourceSites(source_sites)
-
     # used in combination with polynomial coefficients
     epsilons = gmls_helper.getWindowSizes()
     

--- a/pycompadre/examples/test_pycompadre.py
+++ b/pycompadre/examples/test_pycompadre.py
@@ -123,9 +123,6 @@ def remap(polyOrder,dimension,additional_sites=False,epsilon_multiplier=1.5,reco
     gmls_helper.generateKDTree(source_sites)
     gmls_helper.generateNeighborListsFromKNNSearchAndSet(target_sites, polyOrder, dimensions, epsilon_multiplier)
 
-    # set data in gmls object
-    gmls_helper.setSourceSites(source_sites)
-
     # used in combination with polynomial coefficients
     epsilons = gmls_helper.getWindowSizes()
 

--- a/src/Compadre_Evaluator.hpp
+++ b/src/Compadre_Evaluator.hpp
@@ -315,7 +315,7 @@ public:
         auto nla = *(_gmls->getNeighborLists());
         const int num_targets = nla.getNumberOfTargets();
 
-        auto tangent_directions = _gmls->getTangentDirections();
+        auto tangent_directions = *(_gmls->getTangentDirections());
 
         // make sure input and output views have same memory space
         compadre_assert_debug((std::is_same<typename view_type_data_out::memory_space, typename view_type_data_in::memory_space>::value) && 
@@ -567,7 +567,7 @@ public:
 
         // gather needed information for evaluation
         auto coeffs         = _gmls->getFullPolynomialCoefficientsBasis();
-        auto tangent_directions = _gmls->getTangentDirections();
+        auto tangent_directions = *(_gmls->getTangentDirections());
         auto prestencil_weights = _gmls->getPrestencilWeights();
 
         const int num_targets = nla.getNumberOfTargets();

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -9,6 +9,14 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches, const boo
                 && "keep_coefficients is set to true, but number of batches exceeds 1.");
 
     /*
+     *    Verify PointConnections are valid
+     */
+    compadre_assert_debug(this->verifyPointConnections() && 
+            "Source coordinates, target coordinates, and neighbor lists sizes do not match.");
+    compadre_assert_debug(this->verifyAdditionalPointConnections() && 
+            "Target coordinates, additional evaluation sites, and neighbor lists sizes do not match.");
+
+    /*
      *    Generate Quadrature
      */
     this->_qm = Quadrature(_order_of_quadrature_points, _dimension_of_quadrature_points, _quadrature_type);

--- a/src/Compadre_PointConnections.hpp
+++ b/src/Compadre_PointConnections.hpp
@@ -104,6 +104,33 @@ struct PointConnections {
 
 ///@}
 
+/** @name Public Modifiers
+ *  Private function because information lives on the device
+ */
+///@{
+
+    //! Update only target coordinates
+    void setTargetCoordinates(view_type_1 target_coordinates) {
+        _target_coordinates = Kokkos::create_mirror_view<memory_space>(
+                memory_space(), target_coordinates);
+        Kokkos::deep_copy(_target_coordinates, target_coordinates);
+    }
+
+    //! Update only source coordinates
+    void setSourceCoordinates(view_type_2 source_coordinates) {
+        _source_coordinates = Kokkos::create_mirror_view<memory_space>(
+                memory_space(), source_coordinates);
+        Kokkos::deep_copy(_source_coordinates, source_coordinates);
+    }
+
+    //! Update only target coordinates
+    void setNeighborLists(nla_type nla) {
+        _nla = nla;
+    }
+
+
+///@}
+
 /** @name Public Accessors
  */
 ///@{


### PR DESCRIPTION
- Added functionality for setting source, targets, and neighbor lists separately in PointConnections
- Changed logic for how _pc and _additional_pc are filled in GMLS