### PR TITLE
Update PYTHON_EXECUTABLE logic in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,16 +86,16 @@ else() # Raw CMake Project
   bob_option(Compadre_USE_MATLAB "Use MATLAB interface for PYTHON" OFF)
   bob_option(Compadre_USE_MPI "Use MPI (not needed for Compadre toolkit)" OFF)
   set(PYTHON_LIBRARY_PREFIX "..") # relative to examples folder
+  bob_input(PYTHON_EXECUTABLE "" PATH "Python executable location")
+  IF(NOT(PYTHON_EXECUTABLE))
+    MESSAGE(STATUS "Python executable location PYTHON_EXECUTABLE not given. Search made using 'which python'")
+    EXECUTE_PROCESS(
+      COMMAND which "python"
+      OUTPUT_VARIABLE PYTHON_EXECUTABLE
+      OUTPUT_STRIP_TRAILING_WHITESPACE )
+  ENDIF()
+  MESSAGE(STATUS "PYTHON_EXECUTABLE: ${PYTHON_EXECUTABLE}")
   if (Compadre_USE_PYTHON)
-    bob_input(PYTHON_EXECUTABLE "" PATH "Python executable location")
-    IF(NOT(PYTHON_EXECUTABLE))
-      MESSAGE(STATUS "Python executable location PYTHON_EXECUTABLE not given. Search made using 'which python'")
-      EXECUTE_PROCESS(
-        COMMAND which "python"
-        OUTPUT_VARIABLE PYTHON_EXECUTABLE
-        OUTPUT_STRIP_TRAILING_WHITESPACE )
-    ENDIF()
-    MESSAGE(STATUS "PYTHON_EXECUTABLE: ${PYTHON_EXECUTABLE}")
     # change RPATH for a flat directory structure
     # when installing pycompadre as Python package
     if (PYTHON_CALLING_BUILD)


### PR DESCRIPTION
Previous changes replaced `>>python some_example.py` with `>>${PYTHON_EXECUTABLE} some_example.py`, but `PYTHON_EXECUTABLE` is only set if `Compadre_USE_PYTHON` is on, which isn't always the case. This change ensures `PYTHON_EXECUTABLE` is always set.