### PR TITLE
Clean up warnings

### DIFF
--- a/examples/unittests/test_NeighborLists.hpp
+++ b/examples/unittests/test_NeighborLists.hpp
@@ -49,10 +49,10 @@ TEST_F (NeighborListsTest, 2D_to_CompressedRow) {
     ASSERT_EQ (2, nl_f_2d.getNumberOfNeighborsHost(1));
     ASSERT_EQ (3, nl_f_2d.getNumberOfNeighborsHost(2));
     ASSERT_EQ (1, nl_f_2d.getNumberOfNeighborsHost(3));
-    ASSERT_EQ (0, nl_f_2d.getRowOffsetHost(0));
-    ASSERT_EQ (1, nl_f_2d.getRowOffsetHost(1));
-    ASSERT_EQ (3, nl_f_2d.getRowOffsetHost(2));
-    ASSERT_EQ (6, nl_f_2d.getRowOffsetHost(3));
+    ASSERT_EQ ((size_t)0, nl_f_2d.getRowOffsetHost(0));
+    ASSERT_EQ ((size_t)1, nl_f_2d.getRowOffsetHost(1));
+    ASSERT_EQ ((size_t)3, nl_f_2d.getRowOffsetHost(2));
+    ASSERT_EQ ((size_t)6, nl_f_2d.getRowOffsetHost(3));
     ASSERT_EQ (0, nl_f_2d.getNeighborHost(0,0));
     ASSERT_EQ (1, nl_f_2d.getNeighborHost(1,0));
     ASSERT_EQ (2, nl_f_2d.getNeighborHost(1,1));
@@ -61,7 +61,7 @@ TEST_F (NeighborListsTest, 2D_to_CompressedRow) {
     ASSERT_EQ (5, nl_f_2d.getNeighborHost(2,2));
     ASSERT_EQ (6, nl_f_2d.getNeighborHost(3,0));
     ASSERT_EQ (3, nl_f_2d.getMaxNumNeighbors());
-    ASSERT_EQ (7, nl_f_2d.getTotalNeighborsOverAllListsHost());
+    ASSERT_EQ ((size_t)7, nl_f_2d.getTotalNeighborsOverAllListsHost());
 }
 
 #ifdef COMPADRE_EXTREME_DEBUG

--- a/pycompadre/pycompadre.cpp
+++ b/pycompadre/pycompadre.cpp
@@ -120,14 +120,14 @@ struct cknp2d {
     py::array_t<typename T::value_type> result;
     cknp2d (T kokkos_array_host) {
 
-        auto dim_out_0 = kokkos_array_host.extent(0);
-        auto dim_out_1 = kokkos_array_host.extent(1);
+        size_t dim_out_0 = kokkos_array_host.extent(0);
+        size_t dim_out_1 = kokkos_array_host.extent(1);
 
         result = py::array_t<typename T::value_type>(dim_out_0*dim_out_1);
         result.resize({dim_out_0,dim_out_1});
         auto data = result.template mutable_unchecked<T::rank>();
-        Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,dim_out_0), [&](int i) {
-            for (int j=0; j<dim_out_1; ++j) {
+        Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,dim_out_0), [&](size_t i) {
+            for (size_t j=0; j<dim_out_1; ++j) {
                 data(i,j) = kokkos_array_host(i,j);
             }
         });
@@ -618,9 +618,8 @@ public:
             (source_data, lro, sro, true /*scalar_as_vector_if_needed*/, 0);
 
         // get maximum number of additional sites plus target site (+1) per target site
-        int max_additional_sites = gmls_object->getAdditionalEvaluationIndices()->getMaxNumNeighbors() + 1;
+        size_t max_additional_sites = gmls_object->getAdditionalEvaluationIndices()->getMaxNumNeighbors() + 1;
         gmls_object->getAdditionalEvaluationIndices()->computeMinNumNeighbors();
-        int min_additional_sites = gmls_object->getAdditionalEvaluationIndices()->getMinNumNeighbors();
 
         // set dim_out_0 to 1 if setAdditionalEvaluationSitesData never called
         auto additional_evaluation_coords_size = gmls_object->getAdditionalPointConnections()->_source_coordinates.size();
@@ -937,7 +936,7 @@ https://github.com/sandialabs/compadre/blob/master/pycompadre/pycompadre.cpp
             auto lro    = Kokkos::create_mirror_view(d_lro);
             Kokkos::deep_copy(lro, d_lro);
             auto lro_list = py::list();
-            for (int i=0; i<lro.extent(0); ++i) {
+            for (int i=0; i<lro.extent_int(0); ++i) {
                 lro_list.append(lro[i]);
             }
 

--- a/src/Compadre_SolutionSet.hpp
+++ b/src/Compadre_SolutionSet.hpp
@@ -552,8 +552,6 @@ struct SolutionSet {
         auto host_lro_input_tensor_rank = create_mirror_view(_lro_input_tensor_rank);
 
         int total_offset = 0; // need total offset
-        int output_offset = 0;
-        int input_offset = 0;
 
         for (size_t i=0; i<_lro.size(); ++i) {
             host_lro_total_offsets(i) = total_offset;
@@ -568,8 +566,6 @@ struct SolutionSet {
             host_lro_input_tile_size(i) = input_tile_size;
 
             total_offset += input_tile_size * output_tile_size;
-            output_offset += output_tile_size;
-            input_offset += input_tile_size;
 
             // the target functional output rank is based on the output rank of the sampling
             // functional used


### PR DESCRIPTION
Cleaned up sign/unsigned comparisons and unused variables. Clean build with `-Wall` on `apple-clang@14` and `gcc@12`.