### PR TITLE
Fix printf for SYCL

### DIFF
--- a/src/Compadre_LinearAlgebra.cpp
+++ b/src/Compadre_LinearAlgebra.cpp
@@ -101,6 +101,9 @@ namespace GMLS_LinearAlgebra {
       bool do_print = false;
       if (do_print) {
         Kokkos::single(Kokkos::PerTeam(member), [&] () {
+#if KOKKOS_VERSION >= 40200
+          using Kokkos::printf;
+#endif
           //print a
           printf("a=zeros(%lu,%lu);\n", aa.extent(0), aa.extent(1));
               for (size_t i=0; i<aa.extent(0); ++i) {
@@ -132,6 +135,9 @@ namespace GMLS_LinearAlgebra {
 
       if (do_print) {
         Kokkos::single(Kokkos::PerTeam(member), [&] () {
+#if KOKKOS_VERSION >= 40200
+        using Kokkos::printf;
+#endif
         printf("matrix_rank: %d\n", matrix_rank);
         //print u
         printf("u=zeros(%lu,%lu);\n", uu.extent(0), uu.extent(1));

--- a/src/tpl/KokkosBatched_SolveUTV_TeamVector_Internal_Compadre.hpp
+++ b/src/tpl/KokkosBatched_SolveUTV_TeamVector_Internal_Compadre.hpp
@@ -54,7 +54,10 @@ namespace KokkosBatched {
         bool do_print = false;
         if (do_print) {
             Kokkos::single(Kokkos::PerTeam(member), [&] () {
-                printf("size is: %d %d %d %d\n", matrix_rank, m, n, nrhs); 
+#if KOKKOS_VERSION >= 40200
+                using Kokkos::printf;
+#endif
+                printf("size is: %d %d %d %d\n", matrix_rank, m, n, nrhs);
                 printf("U, us1, us0: %d %d\n", us1, us0);
                 printf("T, ts0, ts1: %d %d\n", ts0, ts1);
                 printf("B, bs0, bs1: %d %d\n", bs0, bs1);
@@ -99,6 +102,9 @@ namespace KokkosBatched {
     
             if (do_print) {
                 Kokkos::single(Kokkos::PerTeam(member), [&] () {
+#if KOKKOS_VERSION >= 40200
+                    using Kokkos::printf;
+#endif
                     printf("W=zeros(%d,%d);\n", m, nrhs);
                     for (int i=0; i<m; ++i) {
                         for (int j=0; j<nrhs; ++j) {
@@ -126,6 +132,9 @@ namespace KokkosBatched {
     
             if (do_print) {
                 Kokkos::single(Kokkos::PerTeam(member), [&] () {
+#if KOKKOS_VERSION >= 40200
+                    using Kokkos::printf;
+#endif
                     printf("W=zeros(%d,%d);\n", m, nrhs);
                     for (int i=0; i<m; ++i) {
                         for (int j=0; j<nrhs; ++j) {
@@ -148,6 +157,9 @@ namespace KokkosBatched {
     
             if (do_print) {
                 Kokkos::single(Kokkos::PerTeam(member), [&] () {
+#if KOKKOS_VERSION >= 40200
+                    using Kokkos::printf;
+#endif
                     printf("X=zeros(%d,%d);\n", n, nrhs);
                     for (int i=0; i<n; ++i) {
                         for (int j=0; j<nrhs; ++j) {
@@ -200,6 +212,9 @@ namespace KokkosBatched {
     
             if (do_print) {
                 Kokkos::single(Kokkos::PerTeam(member), [&] () {
+#if KOKKOS_VERSION >= 40200
+                    using Kokkos::printf;
+#endif
                     printf("m=zeros(%d,%d);\n", matrix_rank, nrhs);
                     for (int i=0; i<matrix_rank; ++i) {
                         for (int j=0; j<nrhs; ++j) {
@@ -211,6 +226,9 @@ namespace KokkosBatched {
     
             if (do_print) {
                 Kokkos::single(Kokkos::PerTeam(member), [&] () {
+#if KOKKOS_VERSION >= 40200
+                    using Kokkos::printf;
+#endif
                     printf("T=zeros(%d,%d);\n", m, matrix_rank);
                     for (int i=0; i<m; ++i) {
                         for (int j=0; j<matrix_rank; ++j) {
@@ -232,6 +250,9 @@ namespace KokkosBatched {
     
             if (do_print) {
                 Kokkos::single(Kokkos::PerTeam(member), [&] () {
+#if KOKKOS_VERSION >= 40200
+                    using Kokkos:::printf;
+#endif
                     printf("x=zeros(%d,%d);\n", n, nrhs);
                     for (int i=0; i<n; ++i) {
                         for (int j=0; j<nrhs; ++j) {
@@ -250,6 +271,9 @@ namespace KokkosBatched {
                  X, xs0, xs1);
         if (do_print) {
             Kokkos::single(Kokkos::PerTeam(member), [&] () {
+#if KOKKOS_VERSION >= 40200
+                using Kokkos::printf;
+#endif
                 printf("X=zeros(%d,%d);\n", n, nrhs);
                 for (int i=0; i<n; ++i) {
                     for (int j=0; j<nrhs; ++j) {


### PR DESCRIPTION
- Uses Kokkos::printf() for Kokkos>=4.2
- Contributed from https://github.com/trilinos/Trilinos/pull/12502