### PR TITLE
RKPM kernel weights

### DIFF
--- a/src/Compadre_Basis.hpp
+++ b/src/Compadre_Basis.hpp
@@ -895,7 +895,7 @@ void createWeightsAndP(const BasisData& data, const member_type& teamMember, scr
             }
 
             // generate weight vector from distances and window sizes
-            const double cutoff_p = (data._epsilons_from_sources.extent(0) == 0) ? data._epsilons(target_index) : data._pc.getNeighborIndex(target_index, i);
+            const double cutoff_p = (data._epsilons_from_sources.extent(0) == 0) ? data._epsilons(target_index) : data._epsilons(data._pc.getNeighborIndex(target_index, i));
             w(i+my_num_neighbors*d) = GMLS::Wab(r, cutoff_p, data._weighting_type, data._weighting_p, data._weighting_n);
 
             calcPij<BasisData>(data, teamMember, delta.data(), thread_workspace.data(), target_index, i + d*my_num_neighbors, 0 /*alpha*/, dimension, polynomial_order, false /*bool on only specific order*/, V, reconstruction_space, polynomial_sampling_functional);
@@ -965,7 +965,7 @@ void createWeightsAndPForCurvature(const BasisData& data, const member_type& tea
 
         // ignores V when calculating weights from a point, i.e. uses actual point values
         double r;
-        const double cutoff_p = (data._epsilons_from_sources.extent(0) == 0) ? data._epsilons(target_index) : data._pc.getNeighborIndex(target_index, i);
+        const double cutoff_p = (data._epsilons_from_sources.extent(0) == 0) ? data._epsilons(target_index) : data._epsilons(data._pc.getNeighborIndex(target_index, i));
 
         // get Euclidean distance of scaled relative coordinate from the origin
         if (V==NULL) {

--- a/src/Compadre_Basis.hpp
+++ b/src/Compadre_Basis.hpp
@@ -895,7 +895,8 @@ void createWeightsAndP(const BasisData& data, const member_type& teamMember, scr
             }
 
             // generate weight vector from distances and window sizes
-            w(i+my_num_neighbors*d) = GMLS::Wab(r, data._epsilons(target_index), data._weighting_type, data._weighting_p, data._weighting_n);
+            const double cutoff_p = data._epsilons_from_targets ? data._epsilons(target_index) : data._pc.getNeighborIndex(target_index, i);
+            w(i+my_num_neighbors*d) = GMLS::Wab(r, cutoff_p, data._weighting_type, data._weighting_p, data._weighting_n);
 
             calcPij<BasisData>(data, teamMember, delta.data(), thread_workspace.data(), target_index, i + d*my_num_neighbors, 0 /*alpha*/, dimension, polynomial_order, false /*bool on only specific order*/, V, reconstruction_space, polynomial_sampling_functional);
 
@@ -964,6 +965,7 @@ void createWeightsAndPForCurvature(const BasisData& data, const member_type& tea
 
         // ignores V when calculating weights from a point, i.e. uses actual point values
         double r;
+        const double cutoff_p = data._epsilons_from_targets ? data._epsilons(target_index) : data._pc.getNeighborIndex(target_index, i);
 
         // get Euclidean distance of scaled relative coordinate from the origin
         if (V==NULL) {
@@ -974,10 +976,10 @@ void createWeightsAndPForCurvature(const BasisData& data, const member_type& tea
 
         // generate weight vector from distances and window sizes
         if (only_specific_order) {
-            w(i) = GMLS::Wab(r, data._epsilons(target_index), data._curvature_weighting_type, data._curvature_weighting_p, data._curvature_weighting_n);
+            w(i) = GMLS::Wab(r, cutoff_p, data._curvature_weighting_type, data._curvature_weighting_p, data._curvature_weighting_n);
             calcPij<BasisData>(data, teamMember, delta.data(), thread_workspace.data(), target_index, i, 0 /*alpha*/, dimension, 1, true /*bool on only specific order*/);
         } else {
-            w(i) = GMLS::Wab(r, data._epsilons(target_index), data._curvature_weighting_type, data._curvature_weighting_p, data._curvature_weighting_n);
+            w(i) = GMLS::Wab(r, cutoff_p, data._curvature_weighting_type, data._curvature_weighting_p, data._curvature_weighting_n);
             calcPij<BasisData>(data, teamMember, delta.data(), thread_workspace.data(), target_index, i, 0 /*alpha*/, dimension, data._curvature_poly_order, false /*bool on only specific order*/, V);
         }
 

--- a/src/Compadre_Basis.hpp
+++ b/src/Compadre_Basis.hpp
@@ -895,7 +895,7 @@ void createWeightsAndP(const BasisData& data, const member_type& teamMember, scr
             }
 
             // generate weight vector from distances and window sizes
-            const double cutoff_p = data._epsilons_from_targets ? data._epsilons(target_index) : data._pc.getNeighborIndex(target_index, i);
+            const double cutoff_p = (data._epsilons_from_sources.extent(0) == 0) ? data._epsilons(target_index) : data._pc.getNeighborIndex(target_index, i);
             w(i+my_num_neighbors*d) = GMLS::Wab(r, cutoff_p, data._weighting_type, data._weighting_p, data._weighting_n);
 
             calcPij<BasisData>(data, teamMember, delta.data(), thread_workspace.data(), target_index, i + d*my_num_neighbors, 0 /*alpha*/, dimension, polynomial_order, false /*bool on only specific order*/, V, reconstruction_space, polynomial_sampling_functional);
@@ -965,7 +965,7 @@ void createWeightsAndPForCurvature(const BasisData& data, const member_type& tea
 
         // ignores V when calculating weights from a point, i.e. uses actual point values
         double r;
-        const double cutoff_p = data._epsilons_from_targets ? data._epsilons(target_index) : data._pc.getNeighborIndex(target_index, i);
+        const double cutoff_p = (data._epsilons_from_sources.extent(0) == 0) ? data._epsilons(target_index) : data._pc.getNeighborIndex(target_index, i);
 
         // get Euclidean distance of scaled relative coordinate from the origin
         if (V==NULL) {

--- a/src/Compadre_Functors.hpp
+++ b/src/Compadre_Functors.hpp
@@ -48,6 +48,7 @@ struct GMLSBasisData {
     int _initial_index_for_batch;
     int _order_of_quadrature_points;
     int _dimension_of_quadrature_points;
+    bool _epsilons_from_targets;
 
     GMLS::point_connections_type _pc;
     GMLS::point_connections_type _additional_pc;
@@ -387,7 +388,10 @@ struct AssembleStandardPsqrtW {
 
     GMLSBasisData _data;
 
-    AssembleStandardPsqrtW(GMLSBasisData data) : _data(data) {}
+    AssembleStandardPsqrtW(GMLSBasisData data) : _data(data) {
+        compadre_assert_release(((_data._constraint_type != ConstraintType::NEUMANN_GRAD_SCALAR) || _data._epsilons_from_targets) 
+                && "ConstraintType::NEUMANN_GRAD_SCALAR incompatible with window sizes determined by source sites");
+    }
 
     KOKKOS_INLINE_FUNCTION
     void operator()(const member_type& teamMember) const {

--- a/src/Compadre_Functors.hpp
+++ b/src/Compadre_Functors.hpp
@@ -27,6 +27,7 @@ struct GMLSBasisData {
     Kokkos::View<double**, layout_right> _source_extra_data;
     Kokkos::View<double**, layout_right> _target_extra_data;
     Kokkos::View<double*> _epsilons; 
+    Kokkos::View<double*> _epsilons_from_sources; 
     Kokkos::View<double*****, layout_right> _prestencil_weights; 
     Kokkos::View<TargetOperation*> _curvature_support_operations;
     Kokkos::View<TargetOperation*> _operations;
@@ -48,7 +49,6 @@ struct GMLSBasisData {
     int _initial_index_for_batch;
     int _order_of_quadrature_points;
     int _dimension_of_quadrature_points;
-    bool _epsilons_from_targets;
 
     GMLS::point_connections_type _pc;
     GMLS::point_connections_type _additional_pc;
@@ -388,10 +388,7 @@ struct AssembleStandardPsqrtW {
 
     GMLSBasisData _data;
 
-    AssembleStandardPsqrtW(GMLSBasisData data) : _data(data) {
-        compadre_assert_release(((_data._constraint_type != ConstraintType::NEUMANN_GRAD_SCALAR) || _data._epsilons_from_targets) 
-                && "ConstraintType::NEUMANN_GRAD_SCALAR incompatible with window sizes determined by source sites");
-    }
+    AssembleStandardPsqrtW(GMLSBasisData data) : _data(data) {}
 
     KOKKOS_INLINE_FUNCTION
     void operator()(const member_type& teamMember) const {

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -27,8 +27,9 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches, const boo
     _h_ss._max_evaluation_sites_per_target = _additional_pc._nla.getMaxNumNeighbors() + 1;
 
     // check that window sizes match number of either target or source sites
-    compadre_assert_release((this->_epsilons_from_targets && this->_epsilons.extent(0)==this->_pc._target_coordinates.extent(0))
-            || (!this->_epsilons_from_targets && this->_epsilons.extent(0)==this->_pc._source_coordinates.extent(0)));
+    compadre_assert_release(this->_epsilons.extent(0)==this->_pc._target_coordinates.extent(0));
+    compadre_assert_release(this->_epsilons_from_sources.extent(0)<=0 
+            || this->_epsilons_from_sources.extent(0)==this->_pc._source_coordinates.extent(0));
 
     /*
      *    Generate Quadrature
@@ -531,7 +532,7 @@ const GMLSBasisData GMLS::extractBasisData() const {
     data._target_extra_data = gmls._target_extra_data;
     data._pc = gmls._pc;
     data._epsilons  = gmls._epsilons;
-    data._epsilons_from_targets  = gmls._epsilons_from_targets;
+    data._epsilons_from_sources  = gmls._epsilons_from_sources;
     data._prestencil_weights  = gmls._prestencil_weights;
     data._additional_pc = gmls._additional_pc;
     data._poly_order  = gmls._poly_order;

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -26,6 +26,10 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches, const boo
     _h_ss._neighbor_lists = _pc._nla;
     _h_ss._max_evaluation_sites_per_target = _additional_pc._nla.getMaxNumNeighbors() + 1;
 
+    // check that window sizes match number of either target or source sites
+    compadre_assert_release((this->_epsilons_from_targets && this->_epsilons.extent(0)==this->_pc._target_coordinates.extent(0))
+            || (!this->_epsilons_from_targets && this->_epsilons.extent(0)==this->_pc._source_coordinates.extent(0)));
+
     /*
      *    Generate Quadrature
      */
@@ -526,10 +530,11 @@ const GMLSBasisData GMLS::extractBasisData() const {
     data._source_extra_data = gmls._source_extra_data;
     data._target_extra_data = gmls._target_extra_data;
     data._pc = gmls._pc;
-    data._epsilons  = gmls._epsilons ;
-    data._prestencil_weights  = gmls._prestencil_weights ;
+    data._epsilons  = gmls._epsilons;
+    data._epsilons_from_targets  = gmls._epsilons_from_targets;
+    data._prestencil_weights  = gmls._prestencil_weights;
     data._additional_pc = gmls._additional_pc;
-    data._poly_order  = gmls._poly_order ;
+    data._poly_order  = gmls._poly_order;
     data._curvature_poly_order = gmls._curvature_poly_order;
     data._NP = gmls._NP;
     data._global_dimensions = gmls._global_dimensions;

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -180,6 +180,9 @@ private:
     //! weighting kernel type for curvature problem
     WeightingFunctionType _curvature_weighting_type;
 
+    //! whether kernel support sizes are from targets (true) or source (false)
+    bool _epsilons_from_targets;
+
     //! first parameter to be used for weighting kernel
     int _weighting_p;
 
@@ -428,6 +431,7 @@ public:
 
         _weighting_type = WeightingFunctionType::Power;
         _curvature_weighting_type = WeightingFunctionType::Power;
+        _epsilons_from_targets = true;
         _weighting_p = 2;
         _weighting_n = 1;
         _curvature_weighting_p = 2;
@@ -686,6 +690,11 @@ public:
     //! Type for weighting kernel for curvature 
     WeightingFunctionType getManifoldWeightingType() const { return _curvature_weighting_type; }
 
+    //! Get whether windows sizes is determined by target sites (or false for source sites)
+    bool setWindowSizesFromTargetSites() const {
+        return _epsilons_from_targets;
+    }
+
     //! Get parameter for weighting kernel for GMLS problem
     int getWeightingParameter(const int index = 0) const { 
         if (index==1) {
@@ -872,11 +881,12 @@ public:
             view_type_1 neighbor_lists,
             view_type_2 source_coordinates,
             view_type_3 target_coordinates,
-            view_type_4 epsilons) {
+            view_type_4 epsilons,
+            bool use_epsilons_from_targets = true) {
         this->setNeighborLists<view_type_1>(neighbor_lists);
         this->setSourceSites<view_type_2>(source_coordinates);
         this->setTargetSites<view_type_3>(target_coordinates);
-        this->setWindowSizes<view_type_4>(epsilons);
+        this->setWindowSizes<view_type_4>(epsilons, use_epsilons_from_targets);
     }
 
     //! Sets basic problem data (neighbor lists data, number of neighbors list, source coordinates, and target coordinates)
@@ -886,11 +896,12 @@ public:
             view_type_1 number_of_neighbors_list,
             view_type_2 source_coordinates,
             view_type_3 target_coordinates,
-            view_type_4 epsilons) {
+            view_type_4 epsilons,
+            bool use_epsilons_from_targets = true) {
         this->setNeighborLists<view_type_1>(cr_neighbor_lists, number_of_neighbors_list);
         this->setSourceSites<view_type_2>(source_coordinates);
         this->setTargetSites<view_type_3>(target_coordinates);
-        this->setWindowSizes<view_type_4>(epsilons);
+        this->setWindowSizes<view_type_4>(epsilons, use_epsilons_from_targets);
     }
 
     //! (OPTIONAL) Sets additional evaluation sites for each target site
@@ -1043,11 +1054,10 @@ public:
 
     //! Sets window sizes, also called the support of the kernel
     template<typename view_type>
-    void setWindowSizes(view_type epsilons) {
-
+    void setWindowSizes(view_type epsilons, bool use_epsilons_from_targets = true) {
+        _epsilons_from_targets = use_epsilons_from_targets;
         // allocate memory on device
         _epsilons = decltype(_epsilons)("device epsilons", epsilons.extent(0));
-
         // copy data from host to device
         Kokkos::deep_copy(_epsilons, epsilons);
         this->resetCoefficientData();
@@ -1055,7 +1065,8 @@ public:
 
     //! Sets window sizes, also called the support of the kernel (device)
     template<typename view_type>
-    void setWindowSizes(decltype(_epsilons) epsilons) {
+    void setWindowSizes(decltype(_epsilons) epsilons, bool use_epsilons_from_targets = true) {
+        _epsilons_from_targets = use_epsilons_from_targets;
         // allocate memory on device
         _epsilons = epsilons;
         this->resetCoefficientData();
@@ -1225,6 +1236,12 @@ public:
     void setCurvaturePolynomialOrder(const int curvature_poly_order) {
         compadre_assert_release(curvature_poly_order<11 && "Unsupported curvature polynomial order (>=11).");
         _curvature_poly_order = curvature_poly_order;
+        this->resetCoefficientData();
+    }
+
+    //! Set whether windows sizes is determined by target sites (or false for source sites)
+    void setWindowSizesFromTargetSites(bool from_targets) {
+        _epsilons_from_targets = from_targets;
         this->resetCoefficientData();
     }
 

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -104,6 +104,10 @@ private:
 
     //! h supports determined through neighbor search (device)
     Kokkos::View<double*> _epsilons; 
+
+    //! optional, h supports determined through neighbor search (device)
+    //! which is only used in the kernel
+    Kokkos::View<double*> _epsilons_from_sources; 
     
     //! generated weights for nontraditional samples required to transform data into expected sampling 
     //! functional form (device). 
@@ -179,9 +183,6 @@ private:
 
     //! weighting kernel type for curvature problem
     WeightingFunctionType _curvature_weighting_type;
-
-    //! whether kernel support sizes are from targets (true) or source (false)
-    bool _epsilons_from_targets;
 
     //! first parameter to be used for weighting kernel
     int _weighting_p;
@@ -431,7 +432,6 @@ public:
 
         _weighting_type = WeightingFunctionType::Power;
         _curvature_weighting_type = WeightingFunctionType::Power;
-        _epsilons_from_targets = true;
         _weighting_p = 2;
         _weighting_n = 1;
         _curvature_weighting_p = 2;
@@ -690,11 +690,6 @@ public:
     //! Type for weighting kernel for curvature 
     WeightingFunctionType getManifoldWeightingType() const { return _curvature_weighting_type; }
 
-    //! Get whether windows sizes is determined by target sites (or false for source sites)
-    bool setWindowSizesFromTargetSites() const {
-        return _epsilons_from_targets;
-    }
-
     //! Get parameter for weighting kernel for GMLS problem
     int getWeightingParameter(const int index = 0) const { 
         if (index==1) {
@@ -743,6 +738,12 @@ public:
 
     //! Get a view (device) of all window sizes
     decltype(_epsilons)* getWindowSizes() { return &_epsilons; }
+
+    //! Get a view (device) of all window sizes
+    decltype(_epsilons)* getWindowSizesFromSourceSites() { 
+        compadre_assert_release(this->_epsilons_from_sources.extent(0)>0);
+        return &_epsilons_from_sources; 
+    }
 
     //! Get a view (device) of all tangent direction bundles.
     decltype(_T)* getTangentDirections() { return &_T; }
@@ -881,12 +882,11 @@ public:
             view_type_1 neighbor_lists,
             view_type_2 source_coordinates,
             view_type_3 target_coordinates,
-            view_type_4 epsilons,
-            bool use_epsilons_from_targets = true) {
+            view_type_4 epsilons) {
         this->setNeighborLists<view_type_1>(neighbor_lists);
         this->setSourceSites<view_type_2>(source_coordinates);
         this->setTargetSites<view_type_3>(target_coordinates);
-        this->setWindowSizes<view_type_4>(epsilons, use_epsilons_from_targets);
+        this->setWindowSizes<view_type_4>(epsilons);
     }
 
     //! Sets basic problem data (neighbor lists data, number of neighbors list, source coordinates, and target coordinates)
@@ -896,12 +896,11 @@ public:
             view_type_1 number_of_neighbors_list,
             view_type_2 source_coordinates,
             view_type_3 target_coordinates,
-            view_type_4 epsilons,
-            bool use_epsilons_from_targets = true) {
+            view_type_4 epsilons) {
         this->setNeighborLists<view_type_1>(cr_neighbor_lists, number_of_neighbors_list);
         this->setSourceSites<view_type_2>(source_coordinates);
         this->setTargetSites<view_type_3>(target_coordinates);
-        this->setWindowSizes<view_type_4>(epsilons, use_epsilons_from_targets);
+        this->setWindowSizes<view_type_4>(epsilons);
     }
 
     //! (OPTIONAL) Sets additional evaluation sites for each target site
@@ -1054,8 +1053,7 @@ public:
 
     //! Sets window sizes, also called the support of the kernel
     template<typename view_type>
-    void setWindowSizes(view_type epsilons, bool use_epsilons_from_targets = true) {
-        _epsilons_from_targets = use_epsilons_from_targets;
+    void setWindowSizes(view_type epsilons) {
         // allocate memory on device
         _epsilons = decltype(_epsilons)("device epsilons", epsilons.extent(0));
         // copy data from host to device
@@ -1065,10 +1063,31 @@ public:
 
     //! Sets window sizes, also called the support of the kernel (device)
     template<typename view_type>
-    void setWindowSizes(decltype(_epsilons) epsilons, bool use_epsilons_from_targets = true) {
-        _epsilons_from_targets = use_epsilons_from_targets;
+    void setWindowSizes(decltype(_epsilons) epsilons) {
         // allocate memory on device
         _epsilons = epsilons;
+        this->resetCoefficientData();
+    }
+
+    //! (OPTIONAL)
+    //! Sets window sizes, also called the support of the kernel
+    template<typename view_type>
+    void setWindowSizesFromSourceSites(view_type epsilons) {
+        compadre_assert_release(epsilons.extent(0)==this->_pc._source_coordinates.extent(0));
+        // allocate memory on device
+        _epsilons_from_sources = decltype(_epsilons_from_sources)("device epsilons from source sites", epsilons.extent(0));
+        // copy data from host to device
+        Kokkos::deep_copy(_epsilons, epsilons);
+        this->resetCoefficientData();
+    }
+
+    //! (OPTIONAL)
+    //! Sets window sizes, also called the support of the kernel (device)
+    template<typename view_type>
+    void setWindowSizesFromSourceSites(decltype(_epsilons_from_sources) epsilons) {
+        compadre_assert_release(epsilons.extent(0)==this->_pc._source_coordinates.extent(0));
+        // allocate memory on device
+        _epsilons_from_sources = epsilons;
         this->resetCoefficientData();
     }
 
@@ -1236,12 +1255,6 @@ public:
     void setCurvaturePolynomialOrder(const int curvature_poly_order) {
         compadre_assert_release(curvature_poly_order<11 && "Unsupported curvature polynomial order (>=11).");
         _curvature_poly_order = curvature_poly_order;
-        this->resetCoefficientData();
-    }
-
-    //! Set whether windows sizes is determined by target sites (or false for source sites)
-    void setWindowSizesFromTargetSites(bool from_targets) {
-        _epsilons_from_targets = from_targets;
         this->resetCoefficientData();
     }
 


### PR DESCRIPTION
This PR allows a user to optionally call:
```cpp
gmls_object.setWindowSizesFromSourceSites(epsilons);
```
which will then be used in the weighting kernel.

Traditionally for GMLS, the support window size is determined by the neighborhood of the target sites. However, it is now possible for the support window size to be determined by the neighborhood of the neighbor sites.

Basis functions for evaluating the P matrix and target operator continue to use the window size from the target sites.